### PR TITLE
Solving after displaying 

### DIFF
--- a/application.js
+++ b/application.js
@@ -190,11 +190,10 @@ function getPuzzle(temp_url){
 				puzzle_copy.push(temp);
 			}
 
-	
-			getSol(puzzle_copy);
-		
-			grid.setSol(puzzle_copy);
 			grid.beginNewArray(puzzle);
+			
+			getSol(puzzle_copy);
+			grid.setSol(puzzle_copy);
 		}
 	};
 }


### PR DESCRIPTION
Just switched around the order of solving the puzzle and displaying it. Now, the puzzle is displayed to the user prior to the solver function getting called. This could reduce any unnecessary wait times for the user. Still not sure why the xmlhttp request is taking so long these days